### PR TITLE
Improved dotfile management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-iterm2/
-cabal/
-direnv/

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# from https://jade.fyi/blog/use-nix-less/
+
+scriptdir=$(cd "$(dirname -- "$0")" ; pwd -P)
+
+function symlink() {
+    if [[ -e "$2" && ! -L "$2" ]] ; then 
+        echo "$2 exists and is not a symlink. Ignoring it." >&2
+        return 1
+    fi
+
+    # "ln -sf source link" follows symlinks by default on ancient BSD (thus on macOS)
+    # the fix on ancient BSD is to add -h, which would be incompatible with GNU
+    # which doesn't do any of this nonsense and doesn't accept -h either
+    #
+    [[ -L "$2" ]] && rm "$2"
+
+    ln -sv "${scriptdir}/$1" "$2"
+}
+
+mkdir -p ~/.config
+symlink nvim ~/.config/nvim
+symlink nix-darwin ~/.config/nix-darwin
+symlink system ~/.config/system

--- a/ghc/.gitignore
+++ b/ghc/.gitignore
@@ -1,1 +1,0 @@
-ghci_history

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -58,10 +58,10 @@
       theme = "af-magic";
     };
     shellAliases = {
-      rebuild = "darwin-rebuild switch --flake ~/.config/nix-darwin";
+      rebuild = "~/.config/system/rebuild.sh";
     };
     # Nix-your-shell
-    initExtra = ''
+    initContent = ''
       nix-your-shell zsh | source /dev/stdin
     '';
   };

--- a/system/rebuild.sh
+++ b/system/rebuild.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# from https://jade.fyi/blog/use-nix-less/
+#
+scriptfile=$(readlink -f "$0")
+cd "$(dirname -- "$scriptfile")"
+
+cmd=${1:-switch}
+shift
+# Run the dotfiles script to make the symlinks
+../dotfiles.sh
+sudo darwin-rebuild "$cmd" --flake ~/.config/nix-darwin


### PR DESCRIPTION
Use symlinks to manage dotfiles. Inspired by [You don't have to use Nix to manage your dotfiles](https://jade.fyi/blog/use-nix-less/).